### PR TITLE
Changing environment settings in the init file seems hacky

### DIFF
--- a/scripts/generic/nova-agent.in
+++ b/scripts/generic/nova-agent.in
@@ -47,16 +47,23 @@ then
   . /etc/rc.d/init.d/functions
 fi
 
+prog="nova-agent"
+
+if [ -e "@sysconfdir@/sysconfig/${prog}" ]
+then
+  . @sysconfdir@/sysconfig/${prog}
+fi
+
 prefix="@prefix@"
 exec_prefix="@exec_prefix@"
 sbindir="@sbindir@"
-datadir="@datarootdir@/nova-agent"
+datadir="@datarootdir@/${prog}"
 reallibdir="@prefix@/share/@PACKAGE@/@PACKAGE_VERSION@/lib"
 
-nova_agent="${sbindir}/nova-agent"
+nova_agent="${sbindir}/${prog}"
 agent_config="@prefix@/share/@PACKAGE@/nova-agent.py"
-pidfile="/var/run/nova-agent.pid"
-logfile="/var/log/nova-agent.log"
+pidfile="/var/run/${prog}.pid"
+logfile="/var/log/${prog}.log"
 loglevel="debug"
 
 #####


### PR DESCRIPTION
These changes to allow environment overrides in a manner consistent with EL distros by creating an /etc/sysconfig/nova-agent file and setting environment variables such as 'NOVA_AGENT_RESOLVCONF="off"' there.
