### PR TITLE
Put nameserver info on all subinterfaces of a vif

### DIFF
--- a/commands/debian/network.py
+++ b/commands/debian/network.py
@@ -217,6 +217,8 @@ def _get_file_data(interfaces):
                 if gateway4:
                     file_data += "    gateway %s\n" % gateway4
                     gateway4 = None
+                if dns:
+                    file_data += "    dns-nameservers %s\n" % ' '.join(dns)
 
             if ip6:
                 file_data += "iface %s inet6 static\n" % ifname
@@ -226,10 +228,8 @@ def _get_file_data(interfaces):
                 if gateway6:
                     file_data += "    gateway %s\n" % gateway6
                     gateway6 = None
-
-            if dns:
-                file_data += "    dns-nameservers %s\n" % ' '.join(dns)
-                dns = None
+                if dns:
+                    file_data += "    dns-nameservers %s\n" % ' '.join(dns)
 
             ifname_suffix_num += 1
 


### PR DESCRIPTION
At the moment nova-agent only puts the nameserver info on one of the
subinterfaces of a vif seemingly picked at random. Alot of times
this ends up being the ipv6 configuration section, which causes
the nameserver information to not be loaded when IPv6 is disabled
on the virtual machine. This commit puts the nameserver information
on all of the subinterfaces to prevent this issue from occurring.

Before:

```
auto eth0
iface eth0 inet static
    address 104.130.126.11
    netmask 255.255.255.0
    gateway 104.130.126.1
iface eth0 inet6 static
    address 2001:4800:7818:104:be76:4eff:fe05:3a86
    netmask 64
    gateway fe80::def
    dns-nameservers 72.3.128.241 72.3.128.240
```

After:

```
auto eth0
iface eth0 inet static
    address 104.130.126.11
    netmask 255.255.255.0
    gateway 104.130.126.1
    dns-nameservers 72.3.128.241 72.3.128.240
iface eth0 inet6 static
    address 2001:4800:7818:104:be76:4eff:fe05:3a86
    netmask 64
    gateway fe80::def
    dns-nameservers 72.3.128.241 72.3.128.240
```
