### PR TITLE
Fix for CentOS/RHEL nova agent systemd-python break

### DIFF
--- a/scripts/installer.sh.in
+++ b/scripts/installer.sh.in
@@ -51,7 +51,7 @@ add_to_startup() {
         cat ${dataversdir}/etc/systemd/system/nova-agent.service > /usr/lib/systemd/system/nova-agent.service
         #Populate nova-agent environment file
         echo 'LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:'${reallibdir}'"
-        PYTHONPATH="${PYTHONPATH}:'${reallibdir}'/python2.6/site-packages:'${reallibdir}'/python2.6/"' > /etc/nova-agent.env
+PYTHONPATH="${PYTHONPATH}:'${reallibdir}'/python2.6/site-packages:'${reallibdir}'/python2.6/"' > /etc/nova-agent.env
         systemctl daemon-reload
         /sbin/chkconfig nova-agent on > /dev/null 2>&1
     elif [ -f /sbin/rc-update ] ; then

--- a/scripts/installer.sh.in
+++ b/scripts/installer.sh.in
@@ -47,12 +47,13 @@ add_to_startup() {
             else
                 touch /usr/lib/systemd/system/nova-agent.service
             fi
-        #Populate service file for Rhel/CentOS
-        cat ${dataversdir}/etc/systemd/system/nova-agent.service > /usr/lib/systemd/system/nova-agent.service
-        #Populate nova-agent environment file
-        echo 'LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:'${reallibdir}'"
+            #Populate service file for Rhel/CentOS
+            cat ${dataversdir}/etc/systemd/system/nova-agent.service > /usr/lib/systemd/system/nova-agent.service
+            #Populate nova-agent environment file
+            echo 'LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:'${reallibdir}'"
 PYTHONPATH="${PYTHONPATH}:'${reallibdir}'/python2.6/site-packages:'${reallibdir}'/python2.6/"' > /etc/nova-agent.env
-        systemctl daemon-reload
+            systemctl daemon-reload
+        fi
         /sbin/chkconfig nova-agent on > /dev/null 2>&1
     elif [ -f /sbin/rc-update ] ; then
         # Gentoo style

--- a/scripts/installer.sh.in
+++ b/scripts/installer.sh.in
@@ -41,6 +41,14 @@ add_to_startup() {
         fi
     elif [ -f /sbin/chkconfig ] ; then
         # Red Hat style
+        if [ -d /usr/lib/systemd/system/ ]; then
+            if [ -f /usr/lib/systemd/system/nova-agent.service ]; then
+                echo "Service file exists, moving on"
+            else
+                touch /usr/lib/systemd/system/nova-agent.service
+            fi
+        #Populate service file for Rhel/CentOS
+        cat ${dataversdir}/etc/systemd/system/nova-agent.service > /usr/lib/systemd/system/nova-agent.service
         /sbin/chkconfig nova-agent on > /dev/null 2>&1
     elif [ -f /sbin/rc-update ] ; then
         # Gentoo style

--- a/scripts/installer.sh.in
+++ b/scripts/installer.sh.in
@@ -49,6 +49,7 @@ add_to_startup() {
             fi
         #Populate service file for Rhel/CentOS
         cat ${dataversdir}/etc/systemd/system/nova-agent.service > /usr/lib/systemd/system/nova-agent.service
+        #Populate nova-agent environment file
         echo 'LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:'${reallibdir}'"
         PYTHONPATH="${PYTHONPATH}:'${reallibdir}'/python2.6/site-packages:'${reallibdir}'/python2.6/"' > /etc/nova-agent.env
         systemctl daemon-reload

--- a/scripts/installer.sh.in
+++ b/scripts/installer.sh.in
@@ -49,6 +49,9 @@ add_to_startup() {
             fi
         #Populate service file for Rhel/CentOS
         cat ${dataversdir}/etc/systemd/system/nova-agent.service > /usr/lib/systemd/system/nova-agent.service
+        echo 'LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:'${reallibdir}'"
+        PYTHONPATH="${PYTHONPATH}:'${reallibdir}'/python2.6/site-packages:'${reallibdir}'/python2.6/"' > /etc/nova-agent.env
+        systemctl daemon-reload
         /sbin/chkconfig nova-agent on > /dev/null 2>&1
     elif [ -f /sbin/rc-update ] ; then
         # Gentoo style


### PR DESCRIPTION
A simple edit to the installer to setup the nova agent as a systemd service script upon install for any CentOS/RHEL distributions which has been tested as a preliminary fix to what the new systemd-python package breaks.

-Sean

P.S second iteration to avoid centos/rhel 6 w/o systemd