### PR TITLE
Compatibility patch for glibc 2.20 or later where the _BSD_SOURCE Feature Test Macro has been deprecated.

### DIFF
--- a/lib/agentlib.c
+++ b/lib/agentlib.c
@@ -17,7 +17,7 @@
  *    under the License.
  */
 
-#define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 
 #ifdef HAVE_CONFIG_H
 #include <config.h>

--- a/scripts/gentoo/nova-agent.in
+++ b/scripts/gentoo/nova-agent.in
@@ -1,4 +1,4 @@
-#!/sbin/runscript
+#!/sbin/openrc-run
 
 # vim: tabstop=4 shiftwidth=4 softtabstop=4
 #

--- a/scripts/gentoo/nova-agent.in
+++ b/scripts/gentoo/nova-agent.in
@@ -36,8 +36,8 @@ NOVA_PYTHONPATH=`echo $NOVA_PYTHONPATH | grep 'python[0-9]\.[0-9]'`
 NOVA_PYTHONPATH="${reallibdir}/${NOVA_PYTHONPATH}"
 NOVA_PYTHONPATH="${NOVA_PYTHONPATH}:${NOVA_PYTHONPATH}/site-packages"
 
-if [ `which python > /dev/null 2>&1 ; echo $?` -eq 0 ]; then
-  PYTHONPATH="$(python -c 'import sys; print ":".join(sys.path)')"
+if [ `which python2 > /dev/null 2>&1 ; echo $?` -eq 0 ]; then
+  PYTHONPATH="$(python2 -c 'import sys; print ":".join(sys.path)')"
 fi
 export PYTHONPATH="$NOVA_PYTHONPATH:$PYTHONPATH"
 export PYTHONHOME="$NOVA_PYTHONPATH:$PYTHONPATH"


### PR DESCRIPTION
This patch resolves https://github.com/rackerlabs/openstack-guest-agents-unix/issues/63 where the _BSD_SOURCE Feature Test Macro has been deprecated for builders using glibc 2.20 or later.  Additionally, an OpenRC warning about runscript being deprecated is resolved by patching the init script to use openrc-run.  https://bugs.gentoo.org/show_bug.cgi?id=573846  Lastly, the Gentoo init script is patched to build PYTHONPATH using python2, because there is more than one available Python interpreter and the default is currently python3.4.  (The remedies a SyntaxError starting / stopping Nova Agent when the global default is not python2.7.)